### PR TITLE
feat:#2874 table variants now has list of consent codes for each row

### DIFF
--- a/src/main/scala/org/kidsfirstdrc/dwh/external/dbnsfp/ImportRaw.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/external/dbnsfp/ImportRaw.scala
@@ -1,7 +1,7 @@
 package org.kidsfirstdrc.dwh.external.dbnsfp
 
 import org.apache.spark.sql.{SaveMode, SparkSession}
-import org.apache.spark.sql.functions._
+
 object ImportRaw extends App {
 
   implicit val spark: SparkSession = SparkSession.builder

--- a/src/main/scala/org/kidsfirstdrc/dwh/external/dbnsfp/ImportScores.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/external/dbnsfp/ImportScores.scala
@@ -1,7 +1,7 @@
 package org.kidsfirstdrc.dwh.external.dbnsfp
 
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
 
 object ImportScores extends App {
 
@@ -10,10 +10,9 @@ object ImportScores extends App {
     .enableHiveSupport()
     .appName("Import DBSNFP Scores to DWH").getOrCreate()
 
-  import spark.implicits._
-
   import org.apache.spark.sql.Column
   import org.apache.spark.sql.types.DoubleType
+  import spark.implicits._
 
   def split_semicolon(colName: String, outputColName: String): Column = split(col(colName), ";") as outputColName
 

--- a/src/main/scala/org/kidsfirstdrc/dwh/join/JoinWrite.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/join/JoinWrite.scala
@@ -1,7 +1,6 @@
 package org.kidsfirstdrc.dwh.join
 
-import org.apache.spark.sql.expressions.Window
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession, functions}
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
 object JoinWrite {
 

--- a/src/main/scala/org/kidsfirstdrc/dwh/utils/SparkUtils.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/utils/SparkUtils.scala
@@ -1,7 +1,5 @@
 package org.kidsfirstdrc.dwh.utils
 
-import java.net.URI
-
 import io.projectglow.Glow
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.expressions.{Window, WindowSpec}
@@ -9,6 +7,8 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{ArrayType, DecimalType}
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.kidsfirstdrc.dwh.utils.ClinicalUtils.getGenomicFiles
+
+import java.net.URI
 
 object SparkUtils {
 

--- a/src/main/scala/org/kidsfirstdrc/dwh/variantDbStats/Stats.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/variantDbStats/Stats.scala
@@ -1,4 +1,5 @@
 package org.kidsfirstdrc.dwh.variantDbStats
+
 import org.apache.http.HttpHeaders
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.StringEntity

--- a/src/main/scala/org/kidsfirstdrc/dwh/variantDbStats/StatsUtils.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/variantDbStats/StatsUtils.scala
@@ -1,8 +1,7 @@
 package org.kidsfirstdrc.dwh.variantDbStats
 
-import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions.not
-
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 object StatsUtils {
 

--- a/src/main/scala/org/kidsfirstdrc/dwh/vcf/Occurrences.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/vcf/Occurrences.scala
@@ -1,8 +1,7 @@
 package org.kidsfirstdrc.dwh.vcf
 
-import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession, functions}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.kidsfirstdrc.dwh.utils.ClinicalUtils.{getBiospecimens, getRelations}
 import org.kidsfirstdrc.dwh.utils.SparkUtils._
 import org.kidsfirstdrc.dwh.utils.SparkUtils.columns._

--- a/src/main/scala/org/kidsfirstdrc/dwh/vcf/Variants.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/vcf/Variants.scala
@@ -41,7 +41,8 @@ object Variants {
         $"is_gru",
         $"is_hmb",
         $"variant_class",
-        $"hgvsg"
+        $"hgvsg",
+        $"dbgap_consent_code"
       )
       .groupBy(locus: _*)
       .agg(
@@ -49,12 +50,14 @@ object Variants {
         firstAs("hgvsg") +:
         firstAs("end") +:
         firstAs("variant_class") +:
+        collect_set($"dbgap_consent_code").as("consent_codes") +:
         (freqByDuoCode("hmb") ++ freqByDuoCode("gru")) :_*
       )
       .withColumn("hmb_af", calculated_duo_af("hmb"))
       .withColumn("gru_af", calculated_duo_af("gru"))
       .withColumn("study_id", lit(studyId))
       .withColumn("release_id", lit(releaseId))
+      .withColumn("consent_codes_by_study", map($"study_id", $"consent_codes"))
     variants
   }
 

--- a/src/test/scala/org/kidsfirstdrc/dwh/testutils/Model.scala
+++ b/src/test/scala/org/kidsfirstdrc/dwh/testutils/Model.scala
@@ -16,7 +16,8 @@ object Model {
                           is_hmb: Boolean = true,
                           is_gru: Boolean = false,
                           study_id: String = "SD_123456",
-                          release_id: String = "RE_ABCDEF")
+                          release_id: String = "RE_ABCDEF",
+                          dbgap_consent_code: String = "SD_123456.c1")
 
   case class VariantOutput(chromosome: String = "2",
                            start: Long = 165310406,
@@ -37,7 +38,9 @@ object Model {
                            gru_heterozygotes: Long = 0,
                            variant_class: String = "SNV",
                            study_id: String = "SD_123456",
-                           release_id: String = "RE_ABCDEF")
+                           release_id: String = "RE_ABCDEF",
+                           consent_codes: Set[String] = Set("SD_123456.c1"),
+                           consent_codes_by_study: Map[String, Set[String]] = Map("SD_123456" -> Set("SD_123456.c1")))
 
   case class OccurrencesOutput(chromosome: String,
                                start: Long,
@@ -166,6 +169,8 @@ object Model {
                                gru_homozygotes_by_study: Map[String, Long],
                                gru_heterozygotes_by_study: Map[String, Long],
                                studies: Set[String],
+                               consent_codes: Set[String],
+                               consent_codes_by_study: Map[String, Set[String]],
                                release_id: String = "RE_ABCDEF"
                               )
 

--- a/src/test/scala/org/kidsfirstdrc/dwh/testutils/WithSparkSession.scala
+++ b/src/test/scala/org/kidsfirstdrc/dwh/testutils/WithSparkSession.scala
@@ -1,10 +1,10 @@
 package org.kidsfirstdrc.dwh.testutils
 
-import java.io.File
-import java.nio.file.{Files, Path}
-
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
+
+import java.io.File
+import java.nio.file.{Files, Path}
 
 trait WithSparkSession {
 

--- a/src/test/scala/org/kidsfirstdrc/dwh/vcf/VariantsSpec.scala
+++ b/src/test/scala/org/kidsfirstdrc/dwh/vcf/VariantsSpec.scala
@@ -26,9 +26,9 @@ class VariantsSpec extends AnyFlatSpec with GivenWhenThen with WithSparkSession 
 
   it should "return a dataframe with aggregated frequencies by duo code" in {
     val df = Seq(
-      VariantInput(is_hmb = true, zygosity = "HOM", has_alt = 1),
-      VariantInput(is_hmb = true, is_gru = true, zygosity = "HET", has_alt = 1),
-      VariantInput(is_hmb = false, is_gru = true, zygosity = "HET", has_alt = 1)
+      VariantInput(is_hmb = true, zygosity = "HOM", has_alt = 1, dbgap_consent_code =  "SD_123456.c1"),
+      VariantInput(is_hmb = true, is_gru = true, zygosity = "HET", has_alt = 1, dbgap_consent_code =  "SD_123456.c2"),
+      VariantInput(is_hmb = false, is_gru = true, zygosity = "HET", has_alt = 1, dbgap_consent_code =  "SD_123456.c3")
     ).toDF()
 
     val output = Variants.build(studyId, releaseId, df)
@@ -44,15 +44,10 @@ class VariantsSpec extends AnyFlatSpec with GivenWhenThen with WithSparkSession 
         gru_an = 4,
         gru_af = 0.5,
         gru_homozygotes = 0,
-        gru_heterozygotes = 2)
+        gru_heterozygotes = 2,
+        consent_codes = Set("SD_123456.c1", "SD_123456.c2", "SD_123456.c3"),
+        consent_codes_by_study = Map("SD_123456" -> Set("SD_123456.c1", "SD_123456.c2", "SD_123456.c3")))
     )
   }
-
-  //Array(
-  // VariantOutput(2,165310406,165310406,G,A,chr2:g.166166916G>A,Some(rs1057520413),3,4,0.75,1,1,2,4,0.5,0,2,SNV,SD_123456,RE_ABCDEF))
-  // VariantOutput(2,165310406,165310406,G,A,chr2:g.166166916G>A,Some(rs1057520413),4,3,0.75,1,1,4,2,0.5,0,2,SNV,SD_123456,RE_ABCDEF)
-  // did not contain the same elements as
-  // List(
-  // VariantOutput(2,165310406,165310406,G,A,chr2:g.166166916G>A,Some(rs1057520413),4,3,0.75,1,1,4,2,0.5,0,2,SNV,SD_123456,RE_ABCDEF))
 
 }


### PR DESCRIPTION
Major changes:
- Added a new column **consent_codes**  and **consent_codes_by_study** to variants table based on **dbgap_consent_code** from the occurences table.
