### PR TITLE
fix: now path override works

### DIFF
--- a/bin/run_emr_job_import.sh
+++ b/bin/run_emr_job_import.sh
@@ -3,11 +3,11 @@ set -x
 study_id=$1
 release_id=$2
 study_id_lc=$(echo "$study_id" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
-is_post_cgp_only=${3:-"false"}
-job=${4:-"all"}
-number_instance=${5:-"20"}
-instance_type=${6:-"r5.4xlarge"}
-input_vcf=${7:-"s3a://kf-study-us-east-1-prd-${study_id_lc}/harmonized-data/family-variants"}
+job=${3:-"all"}
+is_pattern_override=${4:-"false"}
+input_vcf=${5:-"s3a://kf-study-us-east-1-prd-${study_id_lc}/harmonized-data/family-variants"}
+number_instance=${6:-"20"}
+instance_type=${7:-"r5.4xlarge"}
 biospecimen_id_column=${8:-"biospecimen_id"}
 
 steps=$(cat <<EOF
@@ -29,7 +29,7 @@ steps=$(cat <<EOF
       "s3a://kf-strides-variant-parquet-prd",
       "${job}",
       "${biospecimen_id_column}",
-      "${is_post_cgp_only}"
+      "${is_pattern_override}"
     ],
     "Type": "CUSTOM_JAR",
     "ActionOnFailure": "TERMINATE_CLUSTER",

--- a/src/main/scala/org/kidsfirstdrc/dwh/vcf/ImportVcf.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/vcf/ImportVcf.scala
@@ -1,33 +1,34 @@
 package org.kidsfirstdrc.dwh.vcf
 
 import org.apache.spark.sql.SparkSession
+import org.kidsfirstdrc.dwh.vcf.ImportVcf.isPatternOverriden
 
 import scala.util.Try
 
 object ImportVcf extends App {
 
-  val Array(studyId, releaseId, input, output, runType, biospecimenIdColumn, isPostCGPOnlyStr) = args
+  val Array(studyId, releaseId, input, output, runType, biospecimenIdColumn, isPatternOverride) = args
 
   implicit val spark: SparkSession = SparkSession.builder
     .config("hive.metastore.client.factory.class", "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory")
     .enableHiveSupport()
     .appName(s"Import $runType for $studyId - $releaseId").getOrCreate()
 
-  val isPostCGPOnly: Boolean = Try(isPostCGPOnlyStr.toBoolean).getOrElse(false)
+  val isPatternOverriden: Boolean = Try(isPatternOverride.toBoolean).getOrElse(false)
 
-  run(studyId, releaseId, input, output, runType, biospecimenIdColumn, isPostCGPOnly)
+  run(studyId, releaseId, input, output, runType, biospecimenIdColumn, isPatternOverriden)
 
   def run(studyId: String, releaseId: String, input: String, output: String,
-          runType: String = "all", biospecimenIdColumn: String = "biospecimen_id", isPostCGPOnly: Boolean = false)
+          runType: String = "all", biospecimenIdColumn: String = "biospecimen_id", isPatternOverriden: Boolean = false)
          (implicit spark: SparkSession): Unit = {
     spark.sql("use variant")
     if (runType == "all") {
-      Occurrences.run(studyId, releaseId, input, output, biospecimenIdColumn, isPostCGPOnly)
+      Occurrences.run(studyId, releaseId, input, output, biospecimenIdColumn, isPatternOverriden)
       Variants.run(studyId, releaseId, input, output)
       Consequences.run(studyId, releaseId, input, output)
     }
     else if (runType == "occurrences")
-      Occurrences.run(studyId, releaseId, input, output, biospecimenIdColumn, isPostCGPOnly)
+      Occurrences.run(studyId, releaseId, input, output, biospecimenIdColumn, isPatternOverriden)
     else if (runType == "variants")
       Variants.run(studyId, releaseId, input, output)
     else if (runType == "consequences")

--- a/src/main/scala/org/kidsfirstdrc/dwh/vcf/Occurrences.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/vcf/Occurrences.scala
@@ -8,12 +8,12 @@ import org.kidsfirstdrc.dwh.utils.SparkUtils.columns._
 
 object Occurrences {
 
-  def run(studyId: String, releaseId: String, input: String, output: String, biospecimenIdColumn: String, isPostCGPOnly: Boolean)(implicit spark: SparkSession): Unit = {
-    write(build(studyId, releaseId, input, biospecimenIdColumn, isPostCGPOnly), output, studyId, releaseId)
+  def run(studyId: String, releaseId: String, input: String, output: String, biospecimenIdColumn: String, isPatternOverriden: Boolean)(implicit spark: SparkSession): Unit = {
+    write(build(studyId, releaseId, input, biospecimenIdColumn, isPatternOverriden), output, studyId, releaseId)
   }
 
-  def build(studyId: String, releaseId: String, input: String, biospecimenIdColumn: String, isPostCGPOnly: Boolean)(implicit spark: SparkSession): DataFrame = {
-    val occurrences = selectOccurrences(studyId, releaseId, input, isPostCGPOnly)
+  def build(studyId: String, releaseId: String, input: String, biospecimenIdColumn: String, isPatternOverriden: Boolean)(implicit spark: SparkSession): DataFrame = {
+    val occurrences = selectOccurrences(studyId, releaseId, input, isPatternOverriden)
     val biospecimens = getBiospecimens(studyId, releaseId, biospecimenIdColumn)
     val withClinical = joinOccurrencesWithClinical(occurrences, biospecimens)
 
@@ -21,10 +21,10 @@ object Occurrences {
     joinOccurrencesWithInheritence(withClinical, relations)
   }
 
-  def selectOccurrences(studyId: String, releaseId: String, input: String, isPostCGPOnly: Boolean)(implicit spark: SparkSession): DataFrame = {
+  def selectOccurrences(studyId: String, releaseId: String, input: String, isPatternOverriden: Boolean)(implicit spark: SparkSession): DataFrame = {
     import spark.implicits._
     val inputDF: DataFrame =
-      if (isPostCGPOnly) loadPostCGP(allFilesPath(input), studyId, releaseId)
+      if (isPatternOverriden) loadPostCGP(input, studyId, releaseId)
       else unionCGPFiles(input, studyId, releaseId)
 
     val occurrences = inputDF

--- a/src/test/resources/tables/genomic_files_override/sd_123456.json
+++ b/src/test/resources/tables/genomic_files_override/sd_123456.json
@@ -1,0 +1,1 @@
+{"file_name": "sample.CGP.filtered.deNovo.vep.vcf.gz", "study_id": "SD_123456"}

--- a/src/test/scala/org/kidsfirstdrc/dwh/vcf/AppFeatureSpec.scala
+++ b/src/test/scala/org/kidsfirstdrc/dwh/vcf/AppFeatureSpec.scala
@@ -32,6 +32,9 @@ class AppFeatureSpec extends AnyFeatureSpec with GivenWhenThen with WithSparkSes
         And("A table genomic_files_re_abcdef that contains only sample.CGP.filtered.deNovo.vep.vcf.gz")
         loadTestClinicalTable("genomic_files", output)
 
+        And("A table genomic_files_override that contains a file to include")
+        loadTestTable("genomic_files_override", output)
+
         And("A table participants_re_abcdef")
         loadTestClinicalTable("participants", output)
 
@@ -122,7 +125,7 @@ class AppFeatureSpec extends AnyFeatureSpec with GivenWhenThen with WithSparkSes
   }
 
 
-  private def loadTestClinicalTable(tableName:String,output: String): Unit = {
+  private def loadTestClinicalTable(tableName:String, output: String): Unit = {
     spark.sql(s"drop table if exists variant.${tableName}_re_abcdef ")
     val genomicFilesDF = spark
       .read
@@ -131,5 +134,16 @@ class AppFeatureSpec extends AnyFeatureSpec with GivenWhenThen with WithSparkSes
       .option("path", s"$output/${tableName}_re_abcdef")
       .format("json")
       .saveAsTable(s"variant.${tableName}_re_abcdef")
+  }
+
+  private def loadTestTable(tableName:String, output: String): Unit = {
+    spark.sql(s"drop table if exists variant.${tableName}")
+    val genomicFilesDF = spark
+      .read
+      .json(getClass.getResource(s"/tables/${tableName}").getFile)
+    genomicFilesDF.write.mode(SaveMode.Overwrite)
+      .option("path", s"$output/${tableName}")
+      .format("json")
+      .saveAsTable(s"variant.${tableName}")
   }
 }


### PR DESCRIPTION
Now the script emr_job_import has 2 different behavior
when **is_pattern_override** is true:
- the **input** argument is used as is to read the path of the vcf files
when **is_pattern_override** is false:
- the **input** argument is suffixed with "/*.CGP.filtered.deNovo.vep.vcf.gz" or "/*.postCGP.filtered.deNovo.vep.vcf.gz" to distinguish  CGP and POST CGP files