### PR TITLE
:sparkles: Add search_text field in gene_centric index

### DIFF
--- a/bin/templates/gene_centric_template.json
+++ b/bin/templates/gene_centric_template.json
@@ -5,7 +5,16 @@
   "priority": 1,
   "template": {
     "settings": {
-      "number_of_shards": 1
+      "number_of_shards": 1,
+      "analysis": {
+        "normalizer": {
+          "custom_normalizer": {
+            "type": "custom",
+            "char_filter": [],
+            "filter": "lowercase"
+          }
+        }
+      }
     },
     "mappings": {
       "properties": {
@@ -99,6 +108,10 @@
         },
         "symbol": {
           "type": "keyword"
+        },
+        "search_text": {
+          "type": "keyword",
+          "normalizer" : "custom_normalizer"
         }
       }
     }

--- a/src/main/scala/org/kidsfirstdrc/dwh/es/index/GeneCentricIndex.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/es/index/GeneCentricIndex.scala
@@ -31,8 +31,10 @@ class GeneCentricIndex(releaseId: String)(override implicit val conf: Configurat
       .withColumn(
         "search_text",
         filter(
+          // Note: array_union([a, b], null) => null whereas array_union([a, b], []) => [a, b]
           array_union(
             array(col("symbol"), col("ensembl_gene_id")),
+            // falling back on [] if no "alias" so that we have: array_union([a, b], []) => [a, b]
             when(col("alias").isNotNull, col("alias")).otherwise(array().cast("array<string>"))
           ),
           x => x.isNotNull && x =!= ""

--- a/src/main/scala/org/kidsfirstdrc/dwh/es/index/GeneCentricIndex.scala
+++ b/src/main/scala/org/kidsfirstdrc/dwh/es/index/GeneCentricIndex.scala
@@ -2,36 +2,50 @@ package org.kidsfirstdrc.dwh.es.index
 
 import bio.ferlab.datalake.commons.config.{Configuration, RunType}
 import bio.ferlab.datalake.spark3.etl.ETL
-import org.apache.spark.sql.functions.{col, sha1}
+import org.apache.spark.sql.functions.{col, sha1, array, filter, array_union, when}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.kidsfirstdrc.dwh.conf.Catalog.{Es, Public}
 
 import java.time.LocalDateTime
 
-class GeneCentricIndex(releaseId: String)
-                      (override implicit val conf: Configuration) extends ETL() {
+class GeneCentricIndex(releaseId: String)(override implicit val conf: Configuration) extends ETL() {
 
   val destination = Es.gene_centric
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
-                       currentRunDateTime: LocalDateTime = LocalDateTime.now())(implicit spark: SparkSession): Map[String, DataFrame] = {
+  override def extract(
+      lastRunDateTime: LocalDateTime = minDateTime,
+      currentRunDateTime: LocalDateTime = LocalDateTime.now()
+  )(implicit spark: SparkSession): Map[String, DataFrame] = {
     Map(
       Public.genes.id -> spark.table(s"${Public.genes.table.get.fullName}")
     )
   }
 
-  override def transform(data: Map[String, DataFrame],
-                         lastRunDateTime: LocalDateTime = minDateTime,
-                         currentRunDateTime: LocalDateTime = LocalDateTime.now())(implicit spark: SparkSession): DataFrame = {
+  override def transform(
+      data: Map[String, DataFrame],
+      lastRunDateTime: LocalDateTime = minDateTime,
+      currentRunDateTime: LocalDateTime = LocalDateTime.now()
+  )(implicit spark: SparkSession): DataFrame = {
     data(Public.genes.id)
       .withColumn("hash", sha1(col("symbol")))
+      .withColumn(
+        "search_text",
+        filter(
+          array_union(
+            array(col("symbol"), col("ensembl_gene_id")),
+            when(col("alias").isNotNull, col("alias")).otherwise(array().cast("array<string>"))
+          ),
+          x => x.isNotNull && x =!= ""
+        )
+      )
   }
 
-  override def load(data: DataFrame,
-                    lastRunDateTime: LocalDateTime = minDateTime,
-                    currentRunDateTime: LocalDateTime = LocalDateTime.now())(implicit spark: SparkSession): DataFrame = {
-    data
-      .write
+  override def load(
+      data: DataFrame,
+      lastRunDateTime: LocalDateTime = minDateTime,
+      currentRunDateTime: LocalDateTime = LocalDateTime.now()
+  )(implicit spark: SparkSession): DataFrame = {
+    data.write
       .mode(SaveMode.Overwrite)
       .option("format", destination.format.sparkFormat)
       .option("path", s"${destination.location}_$releaseId")

--- a/src/test/scala/org/kidsfirstdrc/dwh/es/index/GeneCentricIndexSpec.scala
+++ b/src/test/scala/org/kidsfirstdrc/dwh/es/index/GeneCentricIndexSpec.scala
@@ -10,24 +10,46 @@ import org.scalatest.GivenWhenThen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class GeneCentricIndexSpec
-    extends AnyFlatSpec with GivenWhenThen with WithSparkSession with Matchers {
+class GeneCentricIndexSpec extends AnyFlatSpec with GivenWhenThen with WithSparkSession with Matchers {
   import spark.implicits._
 
-  val genesDf: DataFrame = Seq(
-    GenesOutput()
-  ).toDF()
-
-  val data = Map(
-    Public.genes.id -> genesDf
+  def makeDataMap(g: GenesOutput): Map[String, DataFrame] = Map(
+    Public.genes.id -> Seq(
+      g
+    ).toDF()
   )
 
   implicit val conf: Configuration = Configuration(List())
 
   "Gene_centric index job" should "transform data to the right format" in {
 
-    val result = new GeneCentricIndex("").transform(data)
+    val result = new GeneCentricIndex("").transform(makeDataMap(GenesOutput()))
     result.columns should contain allElementsOf Seq("hash")
     result.as[GeneCentricOutput].collect() should contain allElementsOf Seq(GeneCentricOutput())
+  }
+
+  "Gene_centric index job" should "create a search_text column" in {
+    // all
+    val g0 = GenesOutput(`symbol` = "s0", `alias` = List("a01"), `ensembl_gene_id` = "egi0")
+    val r0 = new GeneCentricIndex("").transform(makeDataMap(g0))
+    r0.columns should contain allElementsOf Seq("search_text")
+    r0.select("search_text").as[List[String]].collect() should contain theSameElementsAs Seq(Seq("s0", "egi0", "a01"))
+
+    // no ensembl_gene_id
+    val g1 = GenesOutput(`symbol` = "s1", `alias` = List("a11", "a12"), `ensembl_gene_id` = null)
+    val r1 = new GeneCentricIndex("").transform(makeDataMap(g1))
+    r1.columns should contain allElementsOf Seq("search_text")
+    r1.select("search_text").as[List[String]].collect() should contain theSameElementsAs Seq(Seq("s1", "a11", "a12"))
+
+    // no alias
+    val g2 = GenesOutput(`symbol` = "s2", `alias` = null, `ensembl_gene_id` = "egi2")
+    val r2 = new GeneCentricIndex("").transform(makeDataMap(g2))
+    r2.columns should contain allElementsOf Seq("search_text")
+    r2.select("search_text").as[List[String]].collect() should contain theSameElementsAs Seq(Seq("s2", "egi2"))
+
+    // edge case
+    val g3 = GenesOutput(`symbol` = null, `alias` = null, `ensembl_gene_id` = null)
+    val r3 = new GeneCentricIndex("").transform(makeDataMap(g3))
+    r3.select("search_text").as[List[String]].collect() shouldBe Seq(Seq())
   }
 }


### PR DESCRIPTION
Addition of `search_text` field in ES simplifies searches in `gene_centric`. This field is the concatenation of `symbol`, `ensembl_id` and `alias` fields.